### PR TITLE
Fix development environment setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4097,6 +4097,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@vercel/analytics": "1.6.1",

--- a/src/app/components/WeatherWidget/WeatherWidget.js
+++ b/src/app/components/WeatherWidget/WeatherWidget.js
@@ -1,4 +1,3 @@
-import React, { ReactElement } from 'react';
 import useFetchWeather from './hooks/useFetchWeather';
 import Image from 'next/image';
 
@@ -23,17 +22,17 @@ function WeatherWidget({ apiKey, geo = undefined }) {
     );
   }
 
-  if (errorMsg) {
+  if (errorMsg || !weatherData?.weather?.[0] || !weatherData?.main || !weatherData?.wind) {
     return (
-      <p
-        style={{
-          color: 'white',
-          fontSize: '30px',
-          height: '80px',
-        }}
-      >
-        {errorMsg}
-      </p>
+      <div className={styles.container}>
+        <p>Weather unavailable</p>
+        <a
+          href="https://www.accuweather.com/en/us/taylorville/62568/weather-forecast/332746"
+          target="blank"
+        >
+          View Pana&apos;s Satellite »
+        </a>
+      </div>
     );
   }
 

--- a/src/app/components/WeatherWidget/hooks/useFetchWeather.js
+++ b/src/app/components/WeatherWidget/hooks/useFetchWeather.js
@@ -8,6 +8,11 @@ export default function useFetchWeather(
   const [state, setState] = useState({ error: null, data: null, loading: true });
   useEffect(() => {
     const fetchWeather = async () => {
+      if (!key) {
+        setState({ error: new Error('Weather currently unavailable'), data: null, loading: false });
+        return;
+      }
+
       const url =
         `${BASE_API_URL}` +
         `?lat=${lat}` +
@@ -17,16 +22,19 @@ export default function useFetchWeather(
       try {
         const response = await fetch(url);
         const result = await response.json();
-        setState({ data: result, loading: false });
+        if (!response.ok) {
+          throw new Error(result?.message || 'Weather currently unavailable');
+        }
+        setState({ data: result, error: null, loading: false });
       } catch (e) {
-        setState({ error: e, loading: false });
+        setState({ error: e, data: null, loading: false });
       }
     }
     fetchWeather();
   }, [key, lat, long]);
 
   const errorMsg =
-    state.data?.error?.message || state.error?.message;
+    state.data?.error?.message || state.data?.message || state.error?.message;
 
   const weatherData = state.data ? state.data : null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Sync `package-lock.json` so clean npm installs succeed.
- Update the lint script to call ESLint directly under Next.js 16.
- Handle missing or failed OpenWeather responses so the shared footer does not crash every page in a fresh dev environment.

### Verification
- `npm ci`
- `npm run build`
- `npm run lint`
- `curl -I http://localhost:3000`
- Manual browser walkthrough of Home, Membership, and Contact pages.

### Walkthrough
[next_dev_environment_keyboard_walkthrough.mp4](https://cursor.com/agents/bc-ca1f60d0-4c2d-47c3-bd33-02b5dd8b0d33/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnext_dev_environment_keyboard_walkthrough.mp4)
[Footer weather fallback](https://cursor.com/agents/bc-ca1f60d0-4c2d-47c3-bd33-02b5dd8b0d33/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweather_fallback_footer.webp)

### Notes
- No PR template was present in the repository.
- The dev server is running at `http://localhost:3000` in the `next-dev-server` tmux session.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca1f60d0-4c2d-47c3-bd33-02b5dd8b0d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca1f60d0-4c2d-47c3-bd33-02b5dd8b0d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

