### PR TITLE
chore(membership): update junior to youth membership

### DIFF
--- a/src/app/api/membership/route.js
+++ b/src/app/api/membership/route.js
@@ -35,7 +35,7 @@ function getMembershipTypeLabel(type) {
   const labels = {
     full: 'Full Membership',
     introductory: 'Introductory Membership',
-    junior: 'Junior Membership',
+    youth: 'Youth Membership',
   };
   return labels[type] || type;
 }

--- a/src/app/membership/apply/page.js
+++ b/src/app/membership/apply/page.js
@@ -111,6 +111,12 @@ function MembershipApplicationContent() {
     }
   }, [searchParams]);
 
+  useEffect(() => {
+    if (formData.membershipType === 'youth' && formData.introductoryDiscount) {
+      setFormData((prev) => ({ ...prev, introductoryDiscount: false }));
+    }
+  }, [formData.membershipType, formData.introductoryDiscount]);
+
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     setFormData((prev) => ({
@@ -199,7 +205,7 @@ function MembershipApplicationContent() {
         </Link>
         <h1>Membership Application</h1>
         <p className={styles.subtitle}>
-          Full, Introductory, Family, &amp; Junior - {currentYear}
+          Full, Introductory, Family, &amp; Youth - {currentYear}
         </p>
         <p className={styles.intro}>
           The Pana Country Club was established to provide its members with the opportunity to play
@@ -228,11 +234,11 @@ function MembershipApplicationContent() {
               <input
                 type="radio"
                 name="membershipType"
-                value="junior"
-                checked={formData.membershipType === 'junior'}
+                value="youth"
+                checked={formData.membershipType === 'youth'}
                 onChange={handleChange}
               />
-              <span>Junior Membership</span>
+              <span>Youth Membership</span>
             </label>
           </div>
 
@@ -286,12 +292,15 @@ function MembershipApplicationContent() {
                     setFormData(prev => ({ ...prev, nonResidentDiscount: false }));
                   }
                 }}
-                disabled={formData.nonResidentDiscount}
+                disabled={formData.nonResidentDiscount || formData.membershipType === 'youth'}
               />
               <div className={styles.discountContent}>
                 <span className={styles.discountName}>Introductory Membership</span>
                 <span className={styles.discountValue}>50% off</span>
-                <p className={styles.discountDesc}>For first-time members (subject to approval)</p>
+                <p className={styles.discountDesc}>
+                  For first-time members (subject to approval).
+                  {formData.membershipType === 'youth' && ' Not available for Youth memberships.'}
+                </p>
               </div>
             </label>
             <label className={styles.discountOption}>

--- a/src/app/membership/page.js
+++ b/src/app/membership/page.js
@@ -169,18 +169,19 @@ export default function MembershipPage() {
 
           <button
             type="button"
-            className={`${styles.card} ${isCardSelected('junior', 'single') ? styles.cardSelected : ''}`}
-            onClick={() => selectMembership('junior', 'single')}
+            className={`${styles.card} ${isCardSelected('youth', 'single') ? styles.cardSelected : ''}`}
+            onClick={() => selectMembership('youth', 'single')}
           >
-            {isCardSelected('junior', 'single') && <IoCheckmarkCircle className={styles.cardCheck} size={24} />}
+            {isCardSelected('youth', 'single') && <IoCheckmarkCircle className={styles.cardCheck} size={24} />}
             <div className={styles.cardIcon}>
               <IoSchoolOutline size={32} />
             </div>
-            <h3>Junior Membership</h3>
-            <div className={styles.price}>${MEMBERSHIP_PRICES.junior.single.toLocaleString()}<span>/year</span></div>
+            <h3>Youth Membership</h3>
+            <div className={styles.price}>${MEMBERSHIP_PRICES.youth.single.toLocaleString()}<span>/year</span></div>
             <p>
-              For family members aged 18-21 enrolled in an accredited degree program.
-              Full access to all club facilities.
+              For youth members 17 and under. Children 12 and under must be
+              accompanied by an adult. Members aged 16 may add a rental cart with
+              proof of a valid driver&apos;s license (cart fees apply).
             </p>
           </button>
 

--- a/src/app/membership/pricingConfig.js
+++ b/src/app/membership/pricingConfig.js
@@ -5,9 +5,9 @@ export const MEMBERSHIP_PRICES = {
     single: 1200,
     family: 1476,
   },
-  junior: {
-    single: 444,
-    family: 444,
+  youth: {
+    single: 300,
+    family: 300,
   },
 };
 
@@ -62,7 +62,9 @@ export function calculatePriceBreakdown(options) {
   // Apply either introductory or non-resident discount (mutually exclusive, both 50%)
   // Introductory applies to membership + cart options
   // Non-Resident only applies to membership (not cart options)
-  const introDiscount = introductoryDiscount ? subtotal * INTRODUCTORY_DISCOUNT : 0;
+  // Youth memberships do not qualify for the Introductory (New Membership) rate.
+  const introEligible = membershipType !== 'youth';
+  const introDiscount = introductoryDiscount && introEligible ? subtotal * INTRODUCTORY_DISCOUNT : 0;
   const nonResDiscount = nonResidentDiscount ? membershipAfterOutOfTown * NON_RESIDENT_DISCOUNT : 0;
   const annualTotal = subtotal - introDiscount - nonResDiscount;
 
@@ -78,7 +80,7 @@ export function calculatePriceBreakdown(options) {
     nonResDiscount,
     nonResidentDiscount,
     annualTotal,
-    membershipLabel: membershipType === 'full' ? 'Full' : 'Junior',
+    membershipLabel: membershipType === 'full' ? 'Full' : 'Youth',
     householdLabel: householdType === 'single' ? 'Individual' : 'Family',
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates membership pricing/selection and discount eligibility logic, which can affect totals shown to users and sent in applications. Risk is moderate due to business-rule changes around discounts and membership type mapping.
> 
> **Overview**
> Renames the `junior` membership tier to **`youth`** across the membership UI, application flow, and emailed application details.
> 
> Updates pricing to the new youth rate (`$300`) and revises copy/eligibility rules so Youth memberships **cannot use the Introductory discount** (UI disables it and pricing calculation ignores it), ensuring consistent totals and application data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25aaf747a11e7cd8ccdce825f441c7d3eb7c3801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->